### PR TITLE
Add server-side settings handling

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -2,6 +2,17 @@
 #define CONFIG_H
 #include <Arduino.h>
 
+struct Thresholds {
+    float lidarMin  = 0;
+    float lidarMax  = 1500;
+    float smokeMin  = 0;
+    float smokeMax  = 400;
+    float eco2Min   = 400;
+    float eco2Max   = 2000;
+    float tvocMin   = 0;
+    float tvocMax   = 600;
+};
+
 struct Settings {
     char siteName[25] = "UNDEF";
     char wifiSSID[33] = "";
@@ -14,6 +25,9 @@ struct Settings {
     char uiUser[17] = "admin";
     char uiPass[33] = "admin";
     bool debugEnable = false;
+    Thresholds thr;
+    uint16_t clogMin = 400;
+    uint8_t clogHold = 2;
 };
 
 extern Settings settings;

--- a/include/MsgBuffer.h
+++ b/include/MsgBuffer.h
@@ -1,0 +1,10 @@
+#ifndef MSGBUFFER_H
+#define MSGBUFFER_H
+#include <Arduino.h>
+#include <LittleFS.h>
+
+void bufferInit();
+void bufferStore(const String& topic, const String& payload);
+void bufferFlush();
+
+#endif

--- a/include/NtpSync.h
+++ b/include/NtpSync.h
@@ -1,0 +1,6 @@
+#ifndef NTPSYNC_H
+#define NTPSYNC_H
+
+void ntpBegin();
+
+#endif

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -17,6 +17,16 @@ void loadSettings() {
     prefs.getString("uiUser", settings.uiUser, sizeof(settings.uiUser));
     prefs.getString("uiPass", settings.uiPass, sizeof(settings.uiPass));
     settings.debugEnable = prefs.getBool("debugEnable", settings.debugEnable);
+    settings.thr.lidarMin = prefs.getFloat("lidarMin", settings.thr.lidarMin);
+    settings.thr.lidarMax = prefs.getFloat("lidarMax", settings.thr.lidarMax);
+    settings.thr.smokeMin = prefs.getFloat("smokeMin", settings.thr.smokeMin);
+    settings.thr.smokeMax = prefs.getFloat("smokeMax", settings.thr.smokeMax);
+    settings.thr.eco2Min  = prefs.getFloat("eco2Min", settings.thr.eco2Min);
+    settings.thr.eco2Max  = prefs.getFloat("eco2Max", settings.thr.eco2Max);
+    settings.thr.tvocMin  = prefs.getFloat("tvocMin", settings.thr.tvocMin);
+    settings.thr.tvocMax  = prefs.getFloat("tvocMax", settings.thr.tvocMax);
+    settings.clogMin = prefs.getUShort("clogMin", settings.clogMin);
+    settings.clogHold = prefs.getUChar("clogHold", settings.clogHold);
     prefs.end();
 }
 
@@ -33,5 +43,15 @@ void saveSettings() {
     prefs.putString("uiUser", settings.uiUser);
     prefs.putString("uiPass", settings.uiPass);
     prefs.putBool("debugEnable", settings.debugEnable);
+    prefs.putFloat("lidarMin", settings.thr.lidarMin);
+    prefs.putFloat("lidarMax", settings.thr.lidarMax);
+    prefs.putFloat("smokeMin", settings.thr.smokeMin);
+    prefs.putFloat("smokeMax", settings.thr.smokeMax);
+    prefs.putFloat("eco2Min", settings.thr.eco2Min);
+    prefs.putFloat("eco2Max", settings.thr.eco2Max);
+    prefs.putFloat("tvocMin", settings.thr.tvocMin);
+    prefs.putFloat("tvocMax", settings.thr.tvocMax);
+    prefs.putUShort("clogMin", settings.clogMin);
+    prefs.putUChar("clogHold", settings.clogHold);
     prefs.end();
 }

--- a/src/MsgBuffer.cpp
+++ b/src/MsgBuffer.cpp
@@ -1,0 +1,24 @@
+#include "MsgBuffer.h"
+
+void bufferInit() {
+    LittleFS.begin(true);
+}
+
+void bufferStore(const String& topic, const String& payload) {
+    File f = LittleFS.open("/buf", FILE_APPEND);
+    if(!f) return;
+    f.println(topic + "|" + payload);
+    f.close();
+}
+
+void bufferFlush() {
+    if(!LittleFS.exists("/buf")) return;
+    File f = LittleFS.open("/buf", FILE_READ);
+    // In real implementation, publish to MQTT
+    while(f.available()) {
+        String line = f.readStringUntil('\n');
+        // publish logic here
+    }
+    f.close();
+    LittleFS.remove("/buf");
+}

--- a/src/NtpSync.cpp
+++ b/src/NtpSync.cpp
@@ -1,0 +1,6 @@
+#include "NtpSync.h"
+#include <time.h>
+
+void ntpBegin() {
+    configTime(0, 0, "pool.ntp.org");
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,9 @@
 #include <ESP32Servo.h>
 #include "Config.h"
 #include "LedFSM.h"
+#include "NtpSync.h"
+#include "MsgBuffer.h"
+#include <ArduinoJson.h>
 
 WiFiClient espClient;
 PubSubClient mqtt(espClient);
@@ -45,13 +48,93 @@ void connectMQTT() {
     }
 }
 
+StaticJsonDocument<512> buildSettingsJson() {
+    StaticJsonDocument<512> doc;
+    doc["siteName"] = settings.siteName;
+    auto wifi = doc.createNestedObject("wifi");
+    wifi["ssid"] = settings.wifiSSID;
+    wifi["password"] = settings.wifiPass;
+    auto mqttj = doc.createNestedObject("mqtt");
+    mqttj["host"] = settings.mqttHost;
+    mqttj["port"] = settings.mqttPort;
+    mqttj["user"] = settings.mqttUser;
+    mqttj["pass"] = settings.mqttPass;
+    mqttj["qos"]  = settings.mqttQos;
+    auto thr = doc.createNestedObject("thresholds");
+    auto l = thr.createNestedObject("lidar");
+    l["min"] = settings.thr.lidarMin; l["max"] = settings.thr.lidarMax;
+    auto s = thr.createNestedObject("smoke");
+    s["min"] = settings.thr.smokeMin; s["max"] = settings.thr.smokeMax;
+    auto e = thr.createNestedObject("eco2");
+    e["min"] = settings.thr.eco2Min; e["max"] = settings.thr.eco2Max;
+    auto t = thr.createNestedObject("tvoc");
+    t["min"] = settings.thr.tvocMin; t["max"] = settings.thr.tvocMax;
+    auto clog = doc.createNestedObject("clog");
+    clog["clogMin"] = settings.clogMin;
+    clog["clogHold"] = settings.clogHold;
+    doc["debugEnable"] = settings.debugEnable;
+    doc["uiUser"] = settings.uiUser;
+    return doc;
+}
+
+void handleSettingsPost(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t, size_t) {
+    StaticJsonDocument<512> doc;
+    if(deserializeJson(doc, data, len)) {
+        request->send(400, "text/plain", "Bad JSON");
+        return;
+    }
+    strlcpy(settings.siteName, doc["siteName"] | settings.siteName, sizeof(settings.siteName));
+    JsonObject wifi = doc["wifi"]; if(!wifi.isNull()) {
+        strlcpy(settings.wifiSSID, wifi["ssid"] | settings.wifiSSID, sizeof(settings.wifiSSID));
+        strlcpy(settings.wifiPass, wifi["password"] | settings.wifiPass, sizeof(settings.wifiPass));
+    }
+    JsonObject mqttj = doc["mqtt"]; if(!mqttj.isNull()) {
+        strlcpy(settings.mqttHost, mqttj["host"] | settings.mqttHost, sizeof(settings.mqttHost));
+        settings.mqttPort = mqttj["port"] | settings.mqttPort;
+        strlcpy(settings.mqttUser, mqttj["user"] | settings.mqttUser, sizeof(settings.mqttUser));
+        strlcpy(settings.mqttPass, mqttj["pass"] | settings.mqttPass, sizeof(settings.mqttPass));
+        settings.mqttQos = mqttj["qos"] | settings.mqttQos;
+    }
+    JsonObject thr = doc["thresholds"]; if(!thr.isNull()) {
+        JsonObject l = thr["lidar"]; if(!l.isNull()) { settings.thr.lidarMin = l["min"] | settings.thr.lidarMin; settings.thr.lidarMax = l["max"] | settings.thr.lidarMax; }
+        JsonObject s = thr["smoke"]; if(!s.isNull()) { settings.thr.smokeMin = s["min"] | settings.thr.smokeMin; settings.thr.smokeMax = s["max"] | settings.thr.smokeMax; }
+        JsonObject e = thr["eco2"]; if(!e.isNull()) { settings.thr.eco2Min = e["min"] | settings.thr.eco2Min; settings.thr.eco2Max = e["max"] | settings.thr.eco2Max; }
+        JsonObject t = thr["tvoc"]; if(!t.isNull()) { settings.thr.tvocMin = t["min"] | settings.thr.tvocMin; settings.thr.tvocMax = t["max"] | settings.thr.tvocMax; }
+    }
+    JsonObject clog = doc["clog"]; if(!clog.isNull()) { settings.clogMin = clog["clogMin"] | settings.clogMin; settings.clogHold = clog["clogHold"] | settings.clogHold; }
+    settings.debugEnable = doc["debugEnable"] | settings.debugEnable;
+    const char *user = doc["uiUser"] | settings.uiUser; strlcpy(settings.uiUser, user, sizeof(settings.uiUser));
+    saveSettings();
+    request->send(200, "text/plain", "OK");
+}
+
+void handlePasswordPost(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t, size_t) {
+    StaticJsonDocument<128> doc;
+    if(deserializeJson(doc, data, len)) { request->send(400, "text/plain", "Bad JSON"); return; }
+    const char* p = doc["password"];
+    if(p) {
+        strlcpy(settings.uiPass, p, sizeof(settings.uiPass));
+        saveSettings();
+    }
+    request->send(200, "text/plain", "OK");
+}
+
 void setupWeb() {
-    server.on("/api/settings", HTTP_POST, [](AsyncWebServerRequest *request){
-        request->send(200, "text/plain", "OK");
+    server.on("/api/settings", HTTP_GET, [](AsyncWebServerRequest *req){
+        StaticJsonDocument<512> doc = buildSettingsJson();
+        String out; serializeJson(doc, out);
+        req->send(200, "application/json", out);
     });
-    server.on("/api/password", HTTP_POST, [](AsyncWebServerRequest *request){
-        request->send(200, "text/plain", "OK");
+    server.on("/api/settings", HTTP_POST, [](AsyncWebServerRequest *request){}, NULL, handleSettingsPost);
+    server.on("/api/password", HTTP_POST, [](AsyncWebServerRequest *request){}, NULL, handlePasswordPost);
+    server.on("/api/live", HTTP_GET, [](AsyncWebServerRequest *req){
+        StaticJsonDocument<256> doc;
+        doc["lidar"] = 0; doc["smoke"] = 0; doc["eco2"] = 0; doc["tvoc"] = 0;
+        doc["temp"] = 0; doc["rh"] = 0; doc["x"] = 0; doc["y"] = 0;
+        String out; serializeJson(doc, out);
+        req->send(200, "application/json", out);
     });
+    server.on("/update", HTTP_POST, [](AsyncWebServerRequest *req){ req->send(200, "text/plain", "OK"); ESP.restart(); });
     server.begin();
 }
 
@@ -61,7 +144,9 @@ void setup() {
     ledInit(2);
     xTaskCreate(ledTask, "led", 1024, nullptr, 1, &ledTaskHandle);
     connectWiFi();
+    ntpBegin();
     connectMQTT();
+    bufferInit();
     setupWeb();
     servoX.attach(4);
     servoY.attach(5);
@@ -69,5 +154,6 @@ void setup() {
 
 void loop() {
     mqtt.loop();
+    if(mqtt.connected()) bufferFlush();
     delay(10);
 }

--- a/web/index.html
+++ b/web/index.html
@@ -37,6 +37,7 @@
 <section id="settings">
 <h2>Настройки</h2>
 <form id="settings-form">
+<label>SiteName <input type="text" id="site-name" name="siteName"></label>
 <details open>
 <summary>Wi-Fi</summary>
 <label>SSID <input type="text" id="wifi-ssid" name="wifiSsid"></label>

--- a/web/script.js
+++ b/web/script.js
@@ -29,6 +29,7 @@
     settingsForm.addEventListener('submit', ev => {
         ev.preventDefault();
         const data = {
+            siteName: document.getElementById('site-name').value,
             wifi: {
                 ssid: document.getElementById('wifi-ssid').value,
                 password: document.getElementById('wifi-pass').value


### PR DESCRIPTION
## Summary
- expand configuration structure with thresholds and clog fields
- implement persistent storage of new fields
- add skeleton modules `NtpSync` and `MsgBuffer`
- implement JSON API for `/api/settings` and `/api/password`
- return dummy live data and OTA endpoint
- expose SiteName field in UI and send it via JS

## Testing
- `platformio run` *(fails: Platform Manager install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2d868d4832a99f73cc06f508819