### PR TITLE
Add periodic NTP resync with timezone

### DIFF
--- a/include/NtpSync.h
+++ b/include/NtpSync.h
@@ -1,6 +1,8 @@
 #ifndef NTPSYNC_H
 #define NTPSYNC_H
 
-void ntpBegin();
+void ntpBegin(long gmtOffsetHours = 0);
+void ntpLoop();
+time_t ntpNow();
 
 #endif

--- a/src/NtpSync.cpp
+++ b/src/NtpSync.cpp
@@ -1,6 +1,25 @@
 #include "NtpSync.h"
 #include <time.h>
 
-void ntpBegin() {
-    configTime(0, 0, "pool.ntp.org");
+static long tzOffset = 0;
+static unsigned long lastSync = 0;
+static const unsigned long syncInterval = 3600UL * 1000UL; // 1 hour
+
+void ntpBegin(long gmtOffsetHours) {
+    tzOffset = gmtOffsetHours * 3600;
+    configTime(tzOffset, 0, "pool.ntp.org");
+    lastSync = millis();
+}
+
+void ntpLoop() {
+    if(millis() - lastSync >= syncInterval) {
+        configTime(tzOffset, 0, "pool.ntp.org");
+        lastSync = millis();
+    }
+}
+
+time_t ntpNow() {
+    time_t now;
+    time(&now);
+    return now;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ void setup() {
 
 void loop() {
     mqtt.loop();
+    ntpLoop();
     if(mqtt.connected()) bufferFlush();
     delay(10);
 }


### PR DESCRIPTION
## Summary
- expand NTP helper with periodic resync and timezone support
- expose current timestamp retrieval
- call the new loop from main

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eca6bf1bc832a9baa49fb656d52e2