### PR TITLE
Add hashed password storage and HTTP auth

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -23,7 +23,8 @@ struct Settings {
     char mqttPass[65] = "";
     uint8_t mqttQos = 0;
     char uiUser[17] = "admin";
-    char uiPass[33] = "admin";
+    // SHA-256 hex string requires 64 characters plus null terminator
+    char uiPass[65] = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918";
     bool debugEnable = false;
     Thresholds thr;
     uint16_t clogMin = 400;
@@ -34,5 +35,6 @@ extern Settings settings;
 
 void loadSettings();
 void saveSettings();
+void hashPassword(const char *input, char output[65]);
 
 #endif // CONFIG_H


### PR DESCRIPTION
## Summary
- store hashed UI password in NVS
- expose `hashPassword()` helper
- enforce HTTP Basic auth on sensitive routes

## Testing
- `platformio run` *(fails: `platformio` couldn't download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684ecc9fd928832a9c95b6b6d33edf7f