### PR TITLE
Add X-Site-Name header to OTA handler

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,6 +360,7 @@ void setupWeb() {
             bool ok = !Update.hasError();
             AsyncWebServerResponse *resp = request->beginResponse(200, "text/plain", ok ? "OK" : "FAIL");
             resp->addHeader("Connection", "close");
+            resp->addHeader("X-Site-Name", settings.siteName);
             request->send(resp);
             if(ok) ESP.restart();
         },
@@ -370,6 +371,7 @@ void setupWeb() {
                 if(!request->authenticate(settings.uiUser, settings.uiPass)) return;
                 if(!Update.begin(UPDATE_SIZE_UNKNOWN)) Update.printError(Serial);
                 progress = request->beginResponseStream("text/plain");
+                progress->addHeader("X-Site-Name", settings.siteName);
                 last = 0;
             }
             if(!Update.hasError()){
@@ -385,6 +387,7 @@ void setupWeb() {
                 else Update.printError(Serial);
                 if(progress){
                     progress->addHeader("Connection", "close");
+                    progress->addHeader("X-Site-Name", settings.siteName);
                     request->send(progress);
                     progress = nullptr;
                 }


### PR DESCRIPTION
## Summary
- include `X-Site-Name` header in OTA responses so clients know which site provided them

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edb9c6b10832aa0bdd9e4f5984c6f