### PR TITLE
Add MQTT event for clog detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,6 +318,9 @@ void sensorsTask(void*) {
             lidarDueMs = 0;
             if(dist < settings.clogMin) {
                 if(++clogCnt >= settings.clogHold) {
+                    if(clogCnt == settings.clogHold) {
+                        publishEvent("clog", dist);
+                    }
                     ledSetState(LedState::ALARM);
                 }
             } else {


### PR DESCRIPTION
## Summary
- trigger `event/clog` MQTT message when clog detection fires

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ede6ac30c832aa9081ef2bc14c990