### PR TITLE
Ensure buffered MQTT messages resend after reconnect

### DIFF
--- a/src/MsgBuffer.cpp
+++ b/src/MsgBuffer.cpp
@@ -1,4 +1,8 @@
 #include "MsgBuffer.h"
+#include "Config.h"
+#include <PubSubClient.h>
+
+extern PubSubClient mqtt;
 
 void bufferInit() {
     LittleFS.begin(true);
@@ -14,10 +18,13 @@ void bufferStore(const String& topic, const String& payload) {
 void bufferFlush() {
     if(!LittleFS.exists("/buf")) return;
     File f = LittleFS.open("/buf", FILE_READ);
-    // In real implementation, publish to MQTT
     while(f.available()) {
         String line = f.readStringUntil('\n');
-        // publish logic here
+        int sep = line.indexOf('|');
+        if(sep <= 0) continue;
+        String topic = line.substring(0, sep);
+        String payload = line.substring(sep + 1);
+        mqtt.publish(topic.c_str(), payload.c_str(), settings.mqttQos, false);
     }
     f.close();
     LittleFS.remove("/buf");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -486,9 +486,17 @@ void setup() {
 }
 
 void loop() {
+    static bool wasConnected = false;
     mqtt.loop();
     ntpLoop();
-    if(mqtt.connected()) bufferFlush();
+    if(!mqtt.connected()) {
+        connectMQTT();
+    }
+    bool connected = mqtt.connected();
+    if(connected && !wasConnected) {
+        bufferFlush();
+    }
+    wasConnected = connected;
 
     unsigned long now = millis();
     if(now - lastHeartbeat >= 3600000) {


### PR DESCRIPTION
## Summary
- publish stored messages from LittleFS in `bufferFlush`
- reconnect to MQTT in `loop` and flush once when connection is restored

## Testing
- `pio run` *(fails: `pio` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ee4d7c74c832a89cc23c7ac148bd5