### PR TITLE
Ensure buffer flush rewrites on failure

### DIFF
--- a/src/MsgBuffer.cpp
+++ b/src/MsgBuffer.cpp
@@ -1,6 +1,7 @@
 #include "MsgBuffer.h"
 #include "Config.h"
 #include <PubSubClient.h>
+#include <vector>
 
 extern PubSubClient mqtt;
 
@@ -17,15 +18,37 @@ void bufferStore(const String& topic, const String& payload) {
 
 void bufferFlush() {
     if(!LittleFS.exists("/buf")) return;
+
+    // Считываем файл и собираем все строки в память
     File f = LittleFS.open("/buf", FILE_READ);
+    std::vector<String> lines;
     while(f.available()) {
-        String line = f.readStringUntil('\n');
+        lines.push_back(f.readStringUntil('\n'));
+    }
+    f.close();
+
+    // Публикуем строки по очереди, останавливаемся при ошибке
+    size_t i = 0;
+    for(; i < lines.size(); ++i) {
+        String line = lines[i];
         int sep = line.indexOf('|');
         if(sep <= 0) continue;
         String topic = line.substring(0, sep);
         String payload = line.substring(sep + 1);
-        mqtt.publish(topic.c_str(), payload.c_str(), settings.mqttQos, false);
+        if(!mqtt.publish(topic.c_str(), payload.c_str(), settings.mqttQos, false)) {
+            break;
+        }
     }
-    f.close();
-    LittleFS.remove("/buf");
+
+    // Если все сообщения отправлены, удаляем файл
+    if(i == lines.size()) {
+        LittleFS.remove("/buf");
+    } else {
+        // Иначе переписываем обратно оставшиеся строки
+        File wf = LittleFS.open("/buf", FILE_WRITE);
+        for(; i < lines.size(); ++i) {
+            wf.println(lines[i]);
+        }
+        wf.close();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure buffered messages are published line by line
- if any publish fails, write remaining lines back into `/buf`
- add Russian comments describing the new logic

## Testing
- `platformio run` *(fails: command not found)*
- `g++ -fsyntax-only -Iinclude -c src/MsgBuffer.cpp` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ef5947bf4832aaeb300d92dd70fdd