### PR TITLE
Update default UI credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ Early warning system for detecting garbage chute clogs based on ESP32-S3.
 
 The `docs/spec_v1.3.md` file contains the current technical specification (in Russian).
 
-UI passwords are stored as SHA-256 hashes.
+UI passwords are stored as SHA-256 hashes. The default web UI credentials are
+`admin` for the username and the SHA‑256 hash `8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918`
+for the password.

--- a/docs/spec_v1.3.md
+++ b/docs/spec_v1.3.md
@@ -53,7 +53,7 @@
 | **Объект**        | `SiteName`                                                       | Строка ≤ 24            | `UNDEF`                            | Отображается в UI, входит в MQTT-топики.                      |
 | **Wi-Fi**         | `SSID`, `Password`                                               | строки                 | —                                  | STA-режим; при пустом SSID запускается AP `start/starttrats`. |
 | **MQTT**          | `Host`, `Port`, `User`, `Pass`, `QoS`                            | host/uint16/строки/0-2 | `broker.hivemq.com` / 1883 / — / 0 | Подключение к брокеру.                                        |
-| **UI-учётка**     | `User`, `Password`            | строки                 | `admin/admin`                      | HTTP Basic, пароль хранится как SHA-256.                     |
+| **UI-учётка**     | `User`, `Password`            | строки                 | `admin/8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918` | HTTP Basic, пароль хранится как SHA-256.                     |
 | **Пороги**        | `Lidar.min/max`, `Smoke.min/max`, `ECO2.min/max`, `TVOC.min/max` | float                  | см. §5                             | События «выброс».                                             |
 | **Clog-алгоритм** | `ClogMin` (мм), `ClogHold` (циклы 10 мин)                        | uint16, uint8          | 400 мм, 2                          | Детектор засора.                                              |
 | **Debug**         | `debugEnable`                                                    | bool                   | `false`                            | Публикация `/debug`.                                          |

--- a/docs/spec_v1.3.md
+++ b/docs/spec_v1.3.md
@@ -53,7 +53,7 @@
 | **Объект**        | `SiteName`                                                       | Строка ≤ 24            | `UNDEF`                            | Отображается в UI, входит в MQTT-топики.                      |
 | **Wi-Fi**         | `SSID`, `Password`                                               | строки                 | —                                  | STA-режим; при пустом SSID запускается AP `start/starttrats`. |
 | **MQTT**          | `Host`, `Port`, `User`, `Pass`, `QoS`                            | host/uint16/строки/0-2 | `broker.hivemq.com` / 1883 / — / 0 | Подключение к брокеру.                                        |
-| **UI-учётка**     | `User`, `Password`            | строки                 | `admin/8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918` | HTTP Basic, пароль хранится как SHA-256.                     |
+| **UI-учётка**     | `User`, `Password`            | строки                 | `admin/admin` | HTTP Basic, пароль хранится как SHA-256.                     |
 | **Пороги**        | `Lidar.min/max`, `Smoke.min/max`, `ECO2.min/max`, `TVOC.min/max` | float                  | см. §5                             | События «выброс».                                             |
 | **Clog-алгоритм** | `ClogMin` (мм), `ClogHold` (циклы 10 мин)                        | uint16, uint8          | 400 мм, 2                          | Детектор засора.                                              |
 | **Debug**         | `debugEnable`                                                    | bool                   | `false`                            | Публикация `/debug`.                                          |

--- a/include/Config.h
+++ b/include/Config.h
@@ -30,7 +30,9 @@ struct Settings {
     char mqttPass[65] = "";
     uint8_t mqttQos = 0;                // Default QoS for publishes
     char uiUser[17] = "admin";          // Web UI credentials (username)
-    char uiPass[65] = "admin";          // Web UI password (SHA256 hash)
+    // Default password is "admin" with SHA-256 applied
+    char uiPass[65] = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918";
+                                         // Web UI password (SHA256 hash)
     bool debugEnable = false;           // If true, publish debug messages
     Thresholds thr;                     // Per-sensor alarm limits
     uint16_t clogMin = 400;             // Distance below which chute clogging is detected (mm)


### PR DESCRIPTION
## Summary
- set default web UI password to the SHA-256 hash of `admin`
- document default credentials in README
- update specification to list hashed default password

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684efcf9a6c8832a9a6167f450a0c177